### PR TITLE
Fix zathura not accepting stdin due to '&' sign

### DIFF
--- a/zathura
+++ b/zathura
@@ -8,10 +8,10 @@ zathura_tmp=$(mktemp -d)
 echo "# temporary zathura config" > "$zathura_tmp/zathurarc"
 
 # get original options
-[ -f $XDG_CONFIG_HOME/zathura/zathurarc ] && cat "$XDG_CONFIG_HOME/zathura/zathurarc" >> "$zathura_tmp/zathurarc" || \
-[ -f $HOME/.config/zathura/zathurarc ] && cat "$HOME/.config/zathura/zathurarc" >> "$zathura_tmp/zathurarc" 
+[ -f "$XDG_CONFIG_HOME/zathura/zathurarc" ] && cat "$XDG_CONFIG_HOME/zathura/zathurarc" >> "$zathura_tmp/zathurarc" || \
+[ -f "$HOME/.config/zathura/zathurarc" ] && cat "$HOME/.config/zathura/zathurarc" >> "$zathura_tmp/zathurarc"
 
 # add the colors
 genzathurarc >> "$zathura_tmp/zathurarc"
 PATH="/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/"
-zathura --config-dir="$zathura_tmp" "$@" &
+zathura --config-dir="$zathura_tmp" "$@"


### PR DESCRIPTION
It seems that the trailing '&' sign after the zathura command makes
zathura open before it can finish reading the standard input, causing it
to fail when the '-' option is used.

The '&' doesn't need to be inside the script - if one wants it, they can
just add it themselves on the command line.